### PR TITLE
fix(bar): Improve the usefulness of bar hover text

### DIFF
--- a/ladybug_charts/to_figure.py
+++ b/ladybug_charts/to_figure.py
@@ -174,7 +174,7 @@ def _monthly_bar(data: MonthlyCollection, var: str, var_unit: str,
         hovertemplate=(
             '<br>%{y} '
             + var_unit
-            + ' in %{customdata[0]}'
+            + ' ' + var
             + '<extra></extra>'),
         marker_color=rgb_to_hex(color),
         marker_line_color='black',


### PR DESCRIPTION
It's fairly obvious which bar is in which month but the color of the data type can sometimes be close to others so it's helpful to have this in the hover text.