### PR TITLE
fix: update plotly version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-plotly==5.8.0
+plotly>=5.10.0
 kaleido==0.0.1rc9
 lbt-ladybug>=0.25.146
 ladybug-pandas==0.4.0


### PR DESCRIPTION
I needed the newer version to access more options for the PC chart.